### PR TITLE
chore(AndroidStudio): Use Android SDK Build Tools 21.1.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion '21.1.2'
 
     defaultConfig {
         applicationId "com.abominableshrine.taptounlock"


### PR DESCRIPTION
Closes https://github.com/psycholold/TapToUnlock/issues/2
